### PR TITLE
Clean up code and use Result instead of panicking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+out.ogg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/HEnquist/lib-rust-oggvorbis-meta"
 keywords = ["ogg", "vorbis", "metadata"]
 categories = ["multimedia::audio"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,3 +19,11 @@ travis-ci = { repository = "HEnquist/lib-rust-oggvorbis-meta" }
 lewton = "0.9.4"
 byteorder = "1.3.2"
 ogg = "0.7"
+
+[lints.clippy.pedantic]
+level = "warn"
+priority = -1
+
+[lints.clippy]
+# emporary until i start using Result
+missing_panics_doc = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ travis-ci = { repository = "HEnquist/lib-rust-oggvorbis-meta" }
 lewton = "0.9.4"
 byteorder = "1.3.2"
 ogg = "0.7"
+thiserror = "1.0.63"
 
 [lints.clippy.pedantic]
 level = "warn"
@@ -27,3 +28,4 @@ priority = -1
 [lints.clippy]
 # emporary until i start using Result
 missing_panics_doc = "allow"
+missing_errors_doc = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,3 @@ thiserror = "1.0.63"
 
 [lints.clippy.pedantic]
 level = "warn"
-priority = -1
-
-[lints.clippy]
-# emporary until i start using Result
-missing_panics_doc = "allow"
-missing_errors_doc = "allow"

--- a/examples/tag_file.rs
+++ b/examples/tag_file.rs
@@ -1,17 +1,13 @@
 // Read and write vorbiscomment metadata
-
-extern crate oggvorbismeta;
-
+use oggvorbismeta::{read_comment_header, replace_comment_header, CommentHeader, VorbisComments};
 use std::env;
 use std::fs::File;
 use std::io::Cursor;
-use oggvorbismeta::{read_comment_header, replace_comment_header, VorbisComments, CommentHeader};
-
 
 fn main() {
     let file_in = env::args().nth(1).expect("Please specify an input file.");
     let file_out = env::args().nth(2).expect("Please specify an output file.");
-    println!("Opening files: {}, {}", file_in, file_out);
+    println!("Opening files: {file_in}, {file_out}");
 
     //open files
     let mut f_in_disk = File::open(file_in).expect("Can't open file");
@@ -19,15 +15,19 @@ fn main() {
 
     println!("Copy input file to buffer");
     std::io::copy(&mut f_in_disk, &mut f_in_ram).unwrap();
-    
+
     let f_in = Cursor::new(&f_in_ram);
     println!("Read comments from file");
     let read_comments = read_comment_header(f_in);
-    
+
     let tag_names = read_comments.get_tag_names();
-    println!("Existing tags: {:?}", tag_names);
-    for tag in tag_names.iter() {
-        println!("Existing tag: {}, {:?}", tag, read_comments.get_tag_multi(tag));
+    println!("Existing tags: {tag_names:?}");
+    for tag in &tag_names {
+        println!(
+            "Existing tag: {}, {:?}",
+            tag,
+            read_comments.get_tag_multi(tag)
+        );
     }
 
     let f_in = Cursor::new(&f_in_ram);
@@ -42,13 +42,13 @@ fn main() {
     new_comment.add_tag_single("date", "1997");
 
     let tag_names = new_comment.get_tag_names();
-    println!("New tags: {:?}", tag_names);
-    for tag in tag_names.iter() {
+    println!("New tags: {tag_names:?}");
+    for tag in &tag_names {
         println!("New tag: {}, {:?}", tag, new_comment.get_tag_multi(tag));
     }
 
     println!("Insert new comments");
-    let mut f_out = replace_comment_header(f_in, new_comment);
+    let mut f_out = replace_comment_header(f_in, &new_comment);
 
     println!("Save to disk");
     let mut f_out_disk = File::create(file_out).unwrap();

--- a/examples/tag_file.rs
+++ b/examples/tag_file.rs
@@ -1,10 +1,12 @@
 // Read and write vorbiscomment metadata
-use oggvorbismeta::{read_comment_header, replace_comment_header, CommentHeader, VorbisComments};
+use oggvorbismeta::{
+    read_comment_header, replace_comment_header, CommentHeader, Result, VorbisComments,
+};
 use std::env;
 use std::fs::File;
 use std::io::Cursor;
 
-fn main() {
+fn main() -> Result<()> {
     let file_in = env::args().nth(1).expect("Please specify an input file.");
     let file_out = env::args().nth(2).expect("Please specify an output file.");
     println!("Opening files: {file_in}, {file_out}");
@@ -18,7 +20,7 @@ fn main() {
 
     let f_in = Cursor::new(&f_in_ram);
     println!("Read comments from file");
-    let read_comments = read_comment_header(f_in);
+    let read_comments = read_comment_header(f_in)?;
 
     let tag_names = read_comments.get_tag_names();
     println!("Existing tags: {tag_names:?}");
@@ -48,9 +50,10 @@ fn main() {
     }
 
     println!("Insert new comments");
-    let mut f_out = replace_comment_header(f_in, &new_comment);
+    let mut f_out = replace_comment_header(f_in, &new_comment)?;
 
     println!("Save to disk");
     let mut f_out_disk = File::create(file_out).unwrap();
     std::io::copy(&mut f_out, &mut f_out_disk).unwrap();
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use thiserror::Error;
 
 pub use lewton::header::CommentHeader;
 
-//type VorbisComments = CommentHeader;
 pub trait VorbisComments {
     fn from(vendor: String, comment_list: Vec<(String, String)>) -> CommentHeader;
     fn new() -> Self;
@@ -132,13 +131,11 @@ pub fn make_comment_header(header: &CommentHeader) -> Result<Vec<u8>> {
     //write each comment
     for comment in &header.comment_list {
         let val = format!("{}={}", comment.0, comment.1);
-        //let commenstrings.last().as_bytes();
         let comment_len: u32 = val.as_bytes().len().try_into()?;
         new_packet.extend(comment_len.to_le_bytes().iter());
         new_packet.extend(val.as_bytes().iter());
     }
     new_packet.push(end);
-    //println!("{:?}",new_packet);
     Ok(new_packet)
 }
 
@@ -178,13 +175,9 @@ pub fn replace_comment_header<T: Read + Seek>(
         };
         if !header_done {
             let comment_hdr = lewton::header::read_header_comment(&packet.data);
-            match comment_hdr {
-                Ok(_hdr) => {
-                    // This is the packet to replace
-                    packet.data.clone_from(&new_comment_data);
-                    header_done = true;
-                }
-                Err(_error) => {}
+            if comment_hdr.is_ok() {
+                packet.data.clone_from(&new_comment_data);
+                header_done = true;
             }
         }
         let lastpacket = packet.last_in_stream() && packet.last_in_page();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use ogg::writing::PacketWriteEndInfo;
 use ogg::{Packet, PacketReader, PacketWriter};
 use std::convert::TryInto;
 use std::io::{Cursor, Read, Seek};
+use thiserror::Error;
 
 pub use lewton::header::CommentHeader;
 
@@ -91,14 +92,26 @@ impl VorbisComments for CommentHeader {
     }
 }
 
-#[must_use]
-pub fn make_comment_header(header: &CommentHeader) -> Vec<u8> {
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("{0}")]
+    OggReadError(#[from] ogg::OggReadError),
+    #[error("{0}")]
+    HeaderReadError(#[from] lewton::header::HeaderReadError),
+    #[error("{0}")]
+    WriteError(#[from] std::io::Error),
+    #[error("{0}")]
+    ParseError(#[from] std::num::TryFromIntError),
+}
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub fn make_comment_header(header: &CommentHeader) -> Result<Vec<u8>> {
     //Signature
     let start = [3u8, 118, 111, 114, 98, 105, 115];
 
     //Vendor number of bytes as u32
     let vendor = header.vendor.as_bytes();
-    let vendor_len: u32 = vendor.len().try_into().unwrap();
+    let vendor_len: u32 = vendor.len().try_into()?;
 
     //end byte
     let end: u8 = 1;
@@ -113,49 +126,40 @@ pub fn make_comment_header(header: &CommentHeader) -> Vec<u8> {
     new_packet.extend(vendor.iter());
 
     //write number of comments
-    let comment_nbr: u32 = header.comment_list.len().try_into().unwrap();
+    let comment_nbr: u32 = header.comment_list.len().try_into()?;
     new_packet.extend(comment_nbr.to_le_bytes().iter());
 
-    let mut commentstrings: Vec<String> = vec![];
     //write each comment
     for comment in &header.comment_list {
-        commentstrings.push(format!("{}={}", comment.0, comment.1));
+        let val = format!("{}={}", comment.0, comment.1);
         //let commenstrings.last().as_bytes();
-        let comment_len: u32 = commentstrings
-            .last()
-            .unwrap()
-            .as_bytes()
-            .len()
-            .try_into()
-            .unwrap();
+        let comment_len: u32 = val.as_bytes().len().try_into()?;
         new_packet.extend(comment_len.to_le_bytes().iter());
-        new_packet.extend(commentstrings.last().unwrap().as_bytes().iter());
+        new_packet.extend(val.as_bytes().iter());
     }
     new_packet.push(end);
     //println!("{:?}",new_packet);
-    new_packet
+    Ok(new_packet)
 }
 
-pub fn read_comment_header<T: Read + Seek>(f_in: T) -> CommentHeader {
+pub fn read_comment_header<T: Read + Seek>(f_in: T) -> Result<CommentHeader> {
     let mut reader = PacketReader::new(f_in);
 
-    let packet: Packet = reader.read_packet_expected().unwrap();
+    let packet: Packet = reader.read_packet_expected()?;
     let stream_serial = packet.stream_serial();
 
-    let mut packet: Packet = reader.read_packet_expected().unwrap();
-    //println!("{:?}",packet.data);
+    let mut packet: Packet = reader.read_packet_expected()?;
     while packet.stream_serial() != stream_serial {
-        packet = reader.read_packet_expected().unwrap();
-        //println!("{:?}",packet.data);
+        packet = reader.read_packet_expected()?;
     }
-    lewton::header::read_header_comment(&packet.data).unwrap()
+    Ok(lewton::header::read_header_comment(&packet.data)?)
 }
 
 pub fn replace_comment_header<T: Read + Seek>(
     f_in: T,
     new_header: &CommentHeader,
-) -> Cursor<Vec<u8>> {
-    let new_comment_data = make_comment_header(new_header);
+) -> Result<Cursor<Vec<u8>>> {
+    let new_comment_data = make_comment_header(new_header)?;
 
     let f_out_ram: Vec<u8> = vec![];
     let mut f_out = Cursor::new(f_out_ram);
@@ -164,55 +168,38 @@ pub fn replace_comment_header<T: Read + Seek>(
     let mut writer = PacketWriter::new(&mut f_out);
 
     let mut header_done = false;
-    loop {
-        let rp = reader.read_packet();
-        match rp {
-            Ok(r) => {
-                match r {
-                    Some(mut packet) => {
-                        let inf = if packet.last_in_stream() {
-                            PacketWriteEndInfo::EndStream
-                        } else if packet.last_in_page() {
-                            PacketWriteEndInfo::EndPage
-                        } else {
-                            PacketWriteEndInfo::NormalPacket
-                        };
-                        if !header_done {
-                            let comment_hdr = lewton::header::read_header_comment(&packet.data);
-                            match comment_hdr {
-                                Ok(_hdr) => {
-                                    // This is the packet to replace
-                                    packet.data.clone_from(&new_comment_data);
-                                    header_done = true;
-                                }
-                                Err(_error) => {}
-                            }
-                        }
-                        let lastpacket = packet.last_in_stream() && packet.last_in_page();
-                        let stream_serial = packet.stream_serial();
-                        let absgp_page = packet.absgp_page();
-                        writer
-                            .write_packet(
-                                packet.data.into_boxed_slice(),
-                                stream_serial,
-                                inf,
-                                absgp_page,
-                            )
-                            .unwrap();
-                        if lastpacket {
-                            break;
-                        }
-                    }
-                    // End of stream
-                    None => break,
+    while let Some(mut packet) = reader.read_packet()? {
+        let inf = if packet.last_in_stream() {
+            PacketWriteEndInfo::EndStream
+        } else if packet.last_in_page() {
+            PacketWriteEndInfo::EndPage
+        } else {
+            PacketWriteEndInfo::NormalPacket
+        };
+        if !header_done {
+            let comment_hdr = lewton::header::read_header_comment(&packet.data);
+            match comment_hdr {
+                Ok(_hdr) => {
+                    // This is the packet to replace
+                    packet.data.clone_from(&new_comment_data);
+                    header_done = true;
                 }
-            }
-            Err(error) => {
-                println!("Error reading packet: {error:?}");
-                break;
+                Err(_error) => {}
             }
         }
+        let lastpacket = packet.last_in_stream() && packet.last_in_page();
+        let stream_serial = packet.stream_serial();
+        let absgp_page = packet.absgp_page();
+        writer.write_packet(
+            packet.data.into_boxed_slice(),
+            stream_serial,
+            inf,
+            absgp_page,
+        )?;
+        if lastpacket {
+            break;
+        }
     }
-    f_out.seek(std::io::SeekFrom::Start(0)).unwrap();
-    f_out
+    f_out.seek(std::io::SeekFrom::Start(0))?;
+    Ok(f_out)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@ pub trait VorbisComments {
     fn get_tag_single(&self, tag: &str) -> Option<String>;
     fn get_tag_multi(&self, tag: &str) -> Vec<String>;
     fn clear_tag(&mut self, tag: &str);
-    fn add_tag_single(&mut self, tag: &str, value: &str);
-    fn add_tag_multi(&mut self, tag: &str, values: &[&str]);
+    fn add_tag_single(&mut self, tag: impl Into<String>, value: impl Into<String>);
+    fn add_tag_multi(&mut self, tag: String, values: &[String]);
     fn get_vendor(&self) -> String;
-    fn set_vendor(&mut self, vend: &str);
+    fn set_vendor(&mut self, vend: impl Into<String>);
 }
 
 impl VorbisComments for CommentHeader {
@@ -52,7 +52,7 @@ impl VorbisComments for CommentHeader {
         if tags.is_empty() {
             None
         } else {
-            Some(tags[0].to_string())
+            Some(tags[0].clone())
         }
     }
 
@@ -60,25 +60,25 @@ impl VorbisComments for CommentHeader {
         self.comment_list
             .clone()
             .iter()
-            .filter(|comment| comment.0.to_lowercase() == tag.to_string().to_lowercase())
+            .filter(|comment| comment.0.to_lowercase() == tag.to_lowercase())
             .map(|comment| comment.1.clone())
             .collect::<Vec<String>>()
     }
 
     fn clear_tag(&mut self, tag: &str) {
         self.comment_list
-            .retain(|comment| comment.0.to_lowercase() != tag.to_string().to_lowercase());
+            .retain(|comment| comment.0.to_lowercase() != tag.to_lowercase());
     }
 
-    fn add_tag_single(&mut self, tag: &str, value: &str) {
+    fn add_tag_single(&mut self, tag: impl Into<String>, value: impl Into<String>) {
         self.comment_list
-            .push((tag.to_string().to_lowercase(), value.to_string()));
+            .push((tag.into().to_lowercase(), value.into()));
     }
 
-    fn add_tag_multi(&mut self, tag: &str, values: &[&str]) {
+    fn add_tag_multi(&mut self, tag: String, values: &[String]) {
         for value in values {
             self.comment_list
-                .push((tag.to_string().to_lowercase(), (*value).to_string()));
+                .push((tag.clone().to_lowercase(), value.clone()));
         }
     }
 
@@ -86,8 +86,8 @@ impl VorbisComments for CommentHeader {
         self.vendor.to_string()
     }
 
-    fn set_vendor(&mut self, vend: &str) {
-        self.vendor = vend.to_string();
+    fn set_vendor(&mut self, vend: impl Into<String>) {
+        self.vendor = vend.into();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,35 +1,28 @@
-// Read and write vorbiscomment metadata
+//! Read and write vorbiscomment metadata
 
-extern crate lewton;
-extern crate byteorder;
-extern crate ogg;
-
-//use lewton::header::CommentHeader;
-use ogg::{PacketReader, PacketWriter, Packet};
 use ogg::writing::PacketWriteEndInfo;
-use std::io::{Cursor, Read, Seek};
+use ogg::{Packet, PacketReader, PacketWriter};
 use std::convert::TryInto;
+use std::io::{Cursor, Read, Seek};
 
-pub type CommentHeader = lewton::header::CommentHeader;
+pub use lewton::header::CommentHeader;
 
 //type VorbisComments = CommentHeader;
 pub trait VorbisComments {
     fn from(vendor: String, comment_list: Vec<(String, String)>) -> CommentHeader;
-    fn new() -> CommentHeader;
-    fn get_tag_names(&self) -> Vec<String> ;
+    fn new() -> Self;
+    fn get_tag_names(&self) -> Vec<String>;
     fn get_tag_single(&self, tag: &str) -> Option<String>;
     fn get_tag_multi(&self, tag: &str) -> Vec<String>;
     fn clear_tag(&mut self, tag: &str);
     fn add_tag_single(&mut self, tag: &str, value: &str);
-    fn add_tag_multi(&mut self, tag: &str, values: &Vec<&str>);
+    fn add_tag_multi(&mut self, tag: &str, values: &[&str]);
     fn get_vendor(&self) -> String;
     fn set_vendor(&mut self, vend: &str);
 }
 
-
 impl VorbisComments for CommentHeader {
-    
-    fn from(vendor: String, comment_list: Vec<(String,String)>) -> CommentHeader {
+    fn from(vendor: String, comment_list: Vec<(String, String)>) -> CommentHeader {
         CommentHeader {
             vendor,
             comment_list,
@@ -38,13 +31,17 @@ impl VorbisComments for CommentHeader {
 
     fn new() -> CommentHeader {
         CommentHeader {
-            vendor : "".to_string(),
-            comment_list : Vec::new(),
+            vendor: String::new(),
+            comment_list: Vec::new(),
         }
     }
 
     fn get_tag_names(&self) -> Vec<String> {
-        let mut names = self.comment_list.iter().map(|comment| comment.0.to_lowercase()).collect::<Vec<String>>();
+        let mut names = self
+            .comment_list
+            .iter()
+            .map(|comment| comment.0.to_lowercase())
+            .collect::<Vec<String>>();
         names.sort_unstable();
         names.dedup();
         names
@@ -52,13 +49,11 @@ impl VorbisComments for CommentHeader {
 
     fn get_tag_single(&self, tag: &str) -> Option<String> {
         let tags = self.get_tag_multi(tag);
-        let result = if tags.len()>0 {
+        if tags.is_empty() {
+            None
+        } else {
             Some(tags[0].to_string())
         }
-        else {
-            None
-        };
-        result
     }
 
     fn get_tag_multi(&self, tag: &str) -> Vec<String> {
@@ -71,16 +66,19 @@ impl VorbisComments for CommentHeader {
     }
 
     fn clear_tag(&mut self, tag: &str) {
-        self.comment_list.retain(|comment| comment.0.to_lowercase() != tag.to_string().to_lowercase());
+        self.comment_list
+            .retain(|comment| comment.0.to_lowercase() != tag.to_string().to_lowercase());
     }
 
     fn add_tag_single(&mut self, tag: &str, value: &str) {
-        self.comment_list.push((tag.to_string().to_lowercase(), value.to_string()));
+        self.comment_list
+            .push((tag.to_string().to_lowercase(), value.to_string()));
     }
 
-    fn add_tag_multi(&mut self, tag: &str, values: &Vec<&str>) {
-        for value in values.iter() {
-            self.comment_list.push((tag.to_string().to_lowercase(), value.to_string()));
+    fn add_tag_multi(&mut self, tag: &str, values: &[&str]) {
+        for value in values {
+            self.comment_list
+                .push((tag.to_string().to_lowercase(), (*value).to_string()));
         }
     }
 
@@ -91,11 +89,9 @@ impl VorbisComments for CommentHeader {
     fn set_vendor(&mut self, vend: &str) {
         self.vendor = vend.to_string();
     }
-
 }
 
-
-
+#[must_use]
 pub fn make_comment_header(header: &CommentHeader) -> Vec<u8> {
     //Signature
     let start = [3u8, 118, 111, 114, 98, 105, 115];
@@ -110,24 +106,30 @@ pub fn make_comment_header(header: &CommentHeader) -> Vec<u8> {
     let mut new_packet: Vec<u8> = vec![];
 
     //write start
-    new_packet.extend(start.iter().cloned());
+    new_packet.extend(start.iter());
 
     //write vendor
-    new_packet.extend(vendor_len.to_le_bytes().iter().cloned());
-    new_packet.extend(vendor.iter().cloned());
+    new_packet.extend(vendor_len.to_le_bytes().iter());
+    new_packet.extend(vendor.iter());
 
     //write number of comments
     let comment_nbr: u32 = header.comment_list.len().try_into().unwrap();
-    new_packet.extend(comment_nbr.to_le_bytes().iter().cloned());
+    new_packet.extend(comment_nbr.to_le_bytes().iter());
 
     let mut commentstrings: Vec<String> = vec![];
     //write each comment
-    for comment in header.comment_list.iter() {
-        commentstrings.push(format!("{}={}",comment.0, comment.1));
+    for comment in &header.comment_list {
+        commentstrings.push(format!("{}={}", comment.0, comment.1));
         //let commenstrings.last().as_bytes();
-        let comment_len: u32 = commentstrings.last().unwrap().as_bytes().len().try_into().unwrap();
-        new_packet.extend(comment_len.to_le_bytes().iter().cloned());
-        new_packet.extend(commentstrings.last().unwrap().as_bytes().iter().cloned());
+        let comment_len: u32 = commentstrings
+            .last()
+            .unwrap()
+            .as_bytes()
+            .len()
+            .try_into()
+            .unwrap();
+        new_packet.extend(comment_len.to_le_bytes().iter());
+        new_packet.extend(commentstrings.last().unwrap().as_bytes().iter());
     }
     new_packet.push(end);
     //println!("{:?}",new_packet);
@@ -135,80 +137,82 @@ pub fn make_comment_header(header: &CommentHeader) -> Vec<u8> {
 }
 
 pub fn read_comment_header<T: Read + Seek>(f_in: T) -> CommentHeader {
-
     let mut reader = PacketReader::new(f_in);
 
-	let packet :Packet = reader.read_packet_expected().unwrap();
+    let packet: Packet = reader.read_packet_expected().unwrap();
     let stream_serial = packet.stream_serial();
 
-	let mut packet: Packet = reader.read_packet_expected().unwrap();
+    let mut packet: Packet = reader.read_packet_expected().unwrap();
     //println!("{:?}",packet.data);
-	while packet.stream_serial() != stream_serial {
-		packet = reader.read_packet_expected().unwrap();
+    while packet.stream_serial() != stream_serial {
+        packet = reader.read_packet_expected().unwrap();
         //println!("{:?}",packet.data);
-	}
-    let comment_hdr = lewton::header::read_header_comment(&packet.data).unwrap();
-    //println!("{:?}", comment_hdr);
-    comment_hdr
+    }
+    lewton::header::read_header_comment(&packet.data).unwrap()
 }
 
-pub fn replace_comment_header<T: Read + Seek>(f_in: T, new_header: CommentHeader) -> Cursor<Vec<u8>> {
-
-    let new_comment_data = make_comment_header(&new_header);
+pub fn replace_comment_header<T: Read + Seek>(
+    f_in: T,
+    new_header: &CommentHeader,
+) -> Cursor<Vec<u8>> {
+    let new_comment_data = make_comment_header(new_header);
 
     let f_out_ram: Vec<u8> = vec![];
     let mut f_out = Cursor::new(f_out_ram);
 
     let mut reader = PacketReader::new(f_in);
-	let mut writer = PacketWriter::new(&mut f_out);
+    let mut writer = PacketWriter::new(&mut f_out);
 
     let mut header_done = false;
-	loop {
-		let rp = reader.read_packet();
+    loop {
+        let rp = reader.read_packet();
         match rp {
             Ok(r) => {
-		        match r {
-			        Some(mut packet) => {
-				        let inf = if packet.last_in_stream() {
-					        PacketWriteEndInfo::EndStream
-				        } else if packet.last_in_page() {
-					        PacketWriteEndInfo::EndPage
-				        } else {
-					        PacketWriteEndInfo::NormalPacket
-				        };
+                match r {
+                    Some(mut packet) => {
+                        let inf = if packet.last_in_stream() {
+                            PacketWriteEndInfo::EndStream
+                        } else if packet.last_in_page() {
+                            PacketWriteEndInfo::EndPage
+                        } else {
+                            PacketWriteEndInfo::NormalPacket
+                        };
                         if !header_done {
                             let comment_hdr = lewton::header::read_header_comment(&packet.data);
                             match comment_hdr {
                                 Ok(_hdr) => {
                                     // This is the packet to replace
-                                    packet.data = new_comment_data.clone();
-                                    header_done=true;
-                                },
+                                    packet.data.clone_from(&new_comment_data);
+                                    header_done = true;
+                                }
                                 Err(_error) => {}
                             }
                         }
                         let lastpacket = packet.last_in_stream() && packet.last_in_page();
-				        let stream_serial = packet.stream_serial();
-				        let absgp_page = packet.absgp_page();
-				        writer.write_packet(packet.data.into_boxed_slice(),
-					        stream_serial,
-					        inf,
-					        absgp_page).unwrap();
+                        let stream_serial = packet.stream_serial();
+                        let absgp_page = packet.absgp_page();
+                        writer
+                            .write_packet(
+                                packet.data.into_boxed_slice(),
+                                stream_serial,
+                                inf,
+                                absgp_page,
+                            )
+                            .unwrap();
                         if lastpacket {
-                            break
+                            break;
                         }
-			        },
-			        // End of stream
-			        None => break,
+                    }
+                    // End of stream
+                    None => break,
                 }
-            },
+            }
             Err(error) => {
-                println!("Error reading packet: {:?}", error);
+                println!("Error reading packet: {error:?}");
                 break;
-            },
-		}
-	}
+            }
+        }
+    }
     f_out.seek(std::io::SeekFrom::Start(0)).unwrap();
     f_out
 }
-


### PR DESCRIPTION
Hello, I came across this library while working on a project of mine and it fits my usecase exactly, except for the fact that it ideally should return `Result` instead of panicking where possible.

I also ran the code through `cargo fmt` and applied `cargo clippy` checks on pedantic mode, to make the code more readable (and in some places, more efficient).

Please give me feedback if you'd like me to change something!